### PR TITLE
Allow double-quoted commands to be instrumented

### DIFF
--- a/instrument.sh
+++ b/instrument.sh
@@ -17,7 +17,7 @@ travis_assert() {
 [{
   "eventType": "BuildCommand",
   "ExitCode": $result,
-  "Command": "${TRAVIS_CMD//\"/}",
+  "Command": "${TRAVIS_CMD//\"/\\\\\"}",
   "Time": $SECONDS,
   "Duration": $[$SECONDS-${LAST_TIME:-$SECONDS}],
   "Branch": "$TRAVIS_BRANCH",

--- a/instrument.sh
+++ b/instrument.sh
@@ -17,7 +17,7 @@ travis_assert() {
 [{
   "eventType": "BuildCommand",
   "ExitCode": $result,
-  "Command": "${TRAVIS_CMD//\"/\\\\\"}",
+  "Command": "${TRAVIS_CMD//\"/\\\"}",
   "Time": $SECONDS,
   "Duration": $[$SECONDS-${LAST_TIME:-$SECONDS}],
   "Branch": "$TRAVIS_BRANCH",

--- a/instrument.sh
+++ b/instrument.sh
@@ -17,7 +17,7 @@ travis_assert() {
 [{
   "eventType": "BuildCommand",
   "ExitCode": $result,
-  "Command": "$TRAVIS_CMD",
+  "Command": "${TRAVIS_CMD//\"/\\\"}",
   "Time": $SECONDS,
   "Duration": $[$SECONDS-${LAST_TIME:-$SECONDS}],
   "Branch": "$TRAVIS_BRANCH",

--- a/instrument.sh
+++ b/instrument.sh
@@ -17,7 +17,7 @@ travis_assert() {
 [{
   "eventType": "BuildCommand",
   "ExitCode": $result,
-  "Command": "${TRAVIS_CMD//\"/\\\"}",
+  "Command": "${TRAVIS_CMD//\"/}",
   "Time": $SECONDS,
   "Duration": $[$SECONDS-${LAST_TIME:-$SECONDS}],
   "Branch": "$TRAVIS_BRANCH",


### PR DESCRIPTION
Currently, any commands in a .travis.yml file that contain double quotes are silently ignored due to JSON validation issues.

This ensures that they are at least captured (though slightly mangled due to shell limitations).