### PR TITLE
Instrument "script" steps (tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ properties:
   currently being built.
 - __Tag__: If the current build is for a git tag, this is set to the tag
   name.
+- __Phase__: If the command is run during the "script" build phase, this
+  is set to "Script" otherwise this is set to "Pre-Script" (useful for
+  distinguishing between build _errors_ and build _fails_).
 
 Once the data is flowing in, you'll be able to run NRQL queries like
 the following:

--- a/instrument.sh
+++ b/instrument.sh
@@ -13,7 +13,7 @@ travis_assert() {
   local result=${1:-$?}
 
   # Log the command to New Relic Insights.
-  log_to_insights $result
+  log_to_insights $result "Pre-Script"
 
   # Fire off the original travis assert method.
   original_travis_assert $result;
@@ -26,7 +26,7 @@ travis_result() {
   export TRAVIS_TEST_RESULT=$(( ${TRAVIS_TEST_RESULT:-0} | $(($result != 0)) ))
 
   # Log the command to New Relic Insights.
-  log_to_insights $result
+  log_to_insights $result "Script"
 
   # Fire off the original travis result method.
   original_travis_result $result;
@@ -51,7 +51,8 @@ log_to_insights() {
   "JobNumber": "$TRAVIS_JOB_NUMBER",
   "BuildOS": "$TRAVIS_OS_NAME",
   "BuildSlug": "$TRAVIS_REPO_SLUG",
-  "Tag": "$TRAVIS_TAG"
+  "Tag": "$TRAVIS_TAG",
+  "Phase": "$2"
 }]
 JSON
 


### PR DESCRIPTION
Looks like `travis_assert` is only run for install/before script steps, while `travis_result` is run for script steps.

This ensures script steps are also captured.